### PR TITLE
test: Added closeToVector utility function

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,8 @@ environment:
 
 dependencies:
   meta: ^1.7.0
-  vector_math: '>=2.1.0 <3.0.0'
+  vector_math: ^2.1.0
 
 dev_dependencies:
-  flutter:
-    sdk: flutter
-  test: ^1.17.0
-  flame_test: ^1.0.1
+  test: ^1.20.0
   flame_lint: ^0.0.1

--- a/test/steering/steerable_test.dart
+++ b/test/steering/steerable_test.dart
@@ -2,16 +2,15 @@ import 'package:radiance/steering.dart';
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import '../utils/close_to_vector.dart';
 import '../utils/simple_steerable.dart';
 
 void main() {
   group('Steerable', () {
     test('properties:read', () {
       final Steerable steerable = SimpleSteerable(velocity: Vector2.all(10));
-      expect(steerable.position.x, 0);
-      expect(steerable.position.y, 0);
-      expect(steerable.velocity.x, 10);
-      expect(steerable.velocity.y, 10);
+      expect(steerable.position, closeToVector(0, 0));
+      expect(steerable.velocity, closeToVector(10, 10));
       expect(steerable.angle, 0);
       expect(steerable.angularVelocity, 0);
     });
@@ -23,10 +22,8 @@ void main() {
       steerable.velocity.setValues(-11, 13);
       steerable.angle = 3.14;
       steerable.angularVelocity = -0.6;
-      expect(steerable.position.x, 5);
-      expect(steerable.position.y, 7);
-      expect(steerable.velocity.x, -11);
-      expect(steerable.velocity.y, 13);
+      expect(steerable.position, closeToVector(5, 7));
+      expect(steerable.velocity, closeToVector(-11, 13));
       expect(steerable.angle, 3.14);
       expect(steerable.angularVelocity, -0.6);
     });

--- a/test/utils/close_to_vector.dart
+++ b/test/utils/close_to_vector.dart
@@ -1,0 +1,43 @@
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+/// Returns a matcher which checks if the argument is a vector within distance
+/// [epsilon] of point ([x], [y]). For example:
+///
+/// ```dart
+/// expect(scale, closeToVector(2, -2));
+/// expect(position, closeToVector(120, 150, epsilon: 1e-10));
+/// ```
+Matcher closeToVector(num x, num y, {double epsilon = 1e-15}) {
+  return _IsCloseTo(Vector2(x.toDouble(), y.toDouble()), epsilon);
+}
+
+class _IsCloseTo extends Matcher {
+  const _IsCloseTo(this._value, this._epsilon);
+
+  final Vector2 _value;
+  final double _epsilon;
+
+  @override
+  bool matches(dynamic item, Map matchState) {
+    return (item is Vector2) && (item - _value).length <= _epsilon;
+  }
+
+  @override
+  Description describe(Description description) => description
+      .add('a Vector2 object within $_epsilon of (${_value.x}, ${_value.y})');
+
+  @override
+  Description describeMismatch(
+      dynamic item,
+      Description mismatchDescription,
+      Map matchState,
+      bool verbose,
+      ) {
+    if (item is! Vector2) {
+      return mismatchDescription.add('is not an instance of Vector2');
+    }
+    final distance = (item - _value).length;
+    return mismatchDescription.add('is at distance $distance');
+  }
+}

--- a/test/utils/close_to_vector.dart
+++ b/test/utils/close_to_vector.dart
@@ -29,11 +29,11 @@ class _IsCloseTo extends Matcher {
 
   @override
   Description describeMismatch(
-      dynamic item,
-      Description mismatchDescription,
-      Map matchState,
-      bool verbose,
-      ) {
+    dynamic item,
+    Description mismatchDescription,
+    Map matchState,
+    bool verbose,
+  ) {
     if (item is! Vector2) {
       return mismatchDescription.add('is not an instance of Vector2');
     }


### PR DESCRIPTION
I wasn't able to use new version of `flame_test`, because it depends on Flutter SDK, and we want Radiance to be a pure-Dart project.

The interim solution is to simply copy the `closeToVector` method over from `flame_test`, and use that. In the future we might be able to use `flame_test` directly.