### PR TITLE
feat: Presets are now grouped into a 2-level menu

### DIFF
--- a/sandbox/lib/main.dart
+++ b/sandbox/lib/main.dart
@@ -38,14 +38,31 @@ class _MyApp extends StatefulWidget {
   State createState() => SandboxState();
 }
 
+/// Main state for the entire app.
 class SandboxState extends State<_MyApp> {
   SandboxState() {
-    currentScene = kPresets[currentPreset]();
+    currentGroup = 0;
+    selectPreset(0);
   }
 
-  int currentPreset = 0;
-  EngineState engineState = EngineState.running;
+  /// Index of the group that is currently open in the left-side menu. If all
+  /// groups are closed, this is `null`.
+  int? currentGroup;
+
+  /// Index of the preset within the currently open group. This should be `null`
+  /// if all groups are closed, or if no presets are selected.
+  int? currentPreset;
+
   late Scene currentScene;
+
+  EngineState engineState = EngineState.running;
+
+  void selectPreset(int? index) {
+    currentPreset = index;
+    if (index != null) {
+      currentScene = Presets.group(currentGroup!).items[index]();
+    }
+  }
 
   void startEngine() {
     setState(() => engineState = EngineState.running);
@@ -58,7 +75,7 @@ class SandboxState extends State<_MyApp> {
   void stopEngine() {
     setState(() {
       engineState = EngineState.stopped;
-      currentScene = kPresets[currentPreset]();
+      selectPreset(currentPreset);
     });
   }
 

--- a/sandbox/lib/main.dart
+++ b/sandbox/lib/main.dart
@@ -65,11 +65,9 @@ class SandboxState extends State<_MyApp> {
 
   EngineState engineState = EngineState.running;
 
-  void selectPreset(int? index) {
+  void selectPreset(int index) {
     currentPreset = index;
-    if (index != null) {
-      currentScene = Presets.group(currentGroup!).items[index]();
-    }
+    currentScene = Presets.makeScene(currentGroup!, index);
   }
 
   void startEngine() {
@@ -83,7 +81,7 @@ class SandboxState extends State<_MyApp> {
   void stopEngine() {
     setState(() {
       engineState = EngineState.stopped;
-      selectPreset(currentPreset);
+      // selectPreset(currentPreset);
     });
   }
 

--- a/sandbox/lib/main.dart
+++ b/sandbox/lib/main.dart
@@ -40,7 +40,7 @@ class _MyApp extends StatefulWidget {
 
 /// Main state for the entire app.
 class SandboxState extends State<_MyApp> {
-  SandboxState(){
+  SandboxState() {
     // Initially, we will show first preset in the first group
     currentGroup = 0;
     currentPreset = 0;
@@ -69,6 +69,12 @@ class SandboxState extends State<_MyApp> {
       currentGroup = groupIndex;
       currentPreset = itemIndex;
       currentScene = Presets.makeScene(groupIndex, itemIndex);
+    });
+  }
+
+  void toggleGroup(int groupIndex) {
+    setState(() {
+      openGroups[groupIndex] = !openGroups[groupIndex];
     });
   }
 

--- a/sandbox/lib/main.dart
+++ b/sandbox/lib/main.dart
@@ -40,18 +40,17 @@ class _MyApp extends StatefulWidget {
 
 /// Main state for the entire app.
 class SandboxState extends State<_MyApp> {
-  SandboxState()
-      : assert(Presets.numGroups > 0, 'Presets must not be empty'),
-        assert(Presets.numItemsInGroup(0) > 0, 'Preset group cannot be empty') {
-    groupOpen[0] = true;
+  SandboxState(){
+    // Initially, we will show first preset in the first group
     currentGroup = 0;
     currentPreset = 0;
+    openGroups[currentGroup!] = true;
     currentScene = Presets.makeScene(0, 0);
   }
 
   /// Boolean indicators for which of the preset groups in the LHS menu are
   /// currently expanded, and which are folded.
-  List<bool> groupOpen = List.filled(Presets.numGroups, false);
+  List<bool> openGroups = List.filled(Presets.numGroups, false);
 
   /// Index of the group in the left-side menu where the current preset belongs
   /// to. If there is no preset selected, this will be `null`.
@@ -65,9 +64,12 @@ class SandboxState extends State<_MyApp> {
 
   EngineState engineState = EngineState.running;
 
-  void selectPreset(int index) {
-    currentPreset = index;
-    currentScene = Presets.makeScene(currentGroup!, index);
+  void selectPreset(int groupIndex, int itemIndex) {
+    setState(() {
+      currentGroup = groupIndex;
+      currentPreset = itemIndex;
+      currentScene = Presets.makeScene(groupIndex, itemIndex);
+    });
   }
 
   void startEngine() {
@@ -81,7 +83,9 @@ class SandboxState extends State<_MyApp> {
   void stopEngine() {
     setState(() {
       engineState = EngineState.stopped;
-      // selectPreset(currentPreset);
+      if (currentGroup != null && currentPreset != null) {
+        selectPreset(currentGroup!, currentPreset!);
+      }
     });
   }
 

--- a/sandbox/lib/main.dart
+++ b/sandbox/lib/main.dart
@@ -40,17 +40,25 @@ class _MyApp extends StatefulWidget {
 
 /// Main state for the entire app.
 class SandboxState extends State<_MyApp> {
-  SandboxState() {
+  SandboxState()
+      : assert(Presets.numGroups > 0, 'Presets must not be empty'),
+        assert(Presets.numItemsInGroup(0) > 0, 'Preset group cannot be empty') {
+    groupOpen[0] = true;
     currentGroup = 0;
-    selectPreset(0);
+    currentPreset = 0;
+    currentScene = Presets.makeScene(0, 0);
   }
 
-  /// Index of the group that is currently open in the left-side menu. If all
-  /// groups are closed, this is `null`.
+  /// Boolean indicators for which of the preset groups in the LHS menu are
+  /// currently expanded, and which are folded.
+  List<bool> groupOpen = List.filled(Presets.numGroups, false);
+
+  /// Index of the group in the left-side menu where the current preset belongs
+  /// to. If there is no preset selected, this will be `null`.
   int? currentGroup;
 
-  /// Index of the preset within the currently open group. This should be `null`
-  /// if all groups are closed, or if no presets are selected.
+  /// Index of the selected preset within the [currentGroup]. If there is no
+  /// preset selected, this will be `null`.
   int? currentPreset;
 
   late Scene currentScene;

--- a/sandbox/lib/presets.dart
+++ b/sandbox/lib/presets.dart
@@ -5,21 +5,39 @@ import 'entities/max_acceleration_entity.dart';
 import 'entities/static_target_entity.dart';
 import 'scene.dart';
 
-final kPresets = [
-  _seek,
-];
+class Presets {
+  static const _presets = [
+    _PresetGroup('Seek', [
+      _seek1,
+    ]),
+  ];
 
-Scene _seek() {
-  final p = Scene('Seek');
-  final target = StaticTargetEntity(position: Vector2(60, 30));
-  final predator = MaxAccelerationEntity(
-    position: Vector2(-40, -40),
-    velocity: Vector2(-10, 10),
-    maxSpeed: 25,
-    maxAcceleration: 15,
-  );
-  predator.behavior = Seek(owner: predator, point: target.position);
-  p.add(target);
-  p.add(predator);
-  return p;
+  static int get numGroups => _presets.length;
+  static _PresetGroup group(int i) => _presets[i];
+
+  //# region Individual presets
+
+  static Scene _seek1() {
+    final p = Scene('Heavy');
+    final target = StaticTargetEntity(position: Vector2(60, 30));
+    final predator = MaxAccelerationEntity(
+      position: Vector2(-40, -40),
+      velocity: Vector2(-10, 10),
+      maxSpeed: 25,
+      maxAcceleration: 15,
+    );
+    predator.behavior = Seek(owner: predator, point: target.position);
+    p.add(target);
+    p.add(predator);
+    return p;
+  }
+
+  //# endregion
+}
+
+class _PresetGroup {
+  const _PresetGroup(this.name, this.items);
+
+  final String name;
+  final List<Scene Function()> items;
 }

--- a/sandbox/lib/presets.dart
+++ b/sandbox/lib/presets.dart
@@ -17,7 +17,7 @@ class Presets {
   static int numItemsInGroup(int i) => _presets[i].items.length;
 
   static Scene makeScene(int groupIndex, int sceneIndex) {
-    return _presets[groupIndex].items[sceneIndex].maker();
+    return _presets[groupIndex].items[sceneIndex].make();
   }
 
   static String sceneName(int groupIndex, int sceneIndex) {
@@ -55,4 +55,6 @@ class _PresetItem {
   const _PresetItem(this.name, this.maker);
   final String name;
   final Scene Function() maker;
+
+  Scene make() => maker();
 }

--- a/sandbox/lib/presets.dart
+++ b/sandbox/lib/presets.dart
@@ -8,7 +8,7 @@ import 'scene.dart';
 class Presets {
   static const _presets = [
     _PresetGroup('Seek', [
-      _seek1,
+      _PresetItem('Heavy', _seek1),
     ]),
   ];
 
@@ -17,7 +17,11 @@ class Presets {
   static int numItemsInGroup(int i) => _presets[i].items.length;
 
   static Scene makeScene(int groupIndex, int sceneIndex) {
-    return _presets[groupIndex].items[sceneIndex]();
+    return _presets[groupIndex].items[sceneIndex].maker();
+  }
+
+  static String sceneName(int groupIndex, int sceneIndex) {
+    return _presets[groupIndex].items[sceneIndex].name;
   }
 
   //# region Individual presets
@@ -44,5 +48,11 @@ class _PresetGroup {
   const _PresetGroup(this.name, this.items);
 
   final String name;
-  final List<Scene Function()> items;
+  final List<_PresetItem> items;
+}
+
+class _PresetItem {
+  const _PresetItem(this.name, this.maker);
+  final String name;
+  final Scene Function() maker;
 }

--- a/sandbox/lib/presets.dart
+++ b/sandbox/lib/presets.dart
@@ -14,6 +14,11 @@ class Presets {
 
   static int get numGroups => _presets.length;
   static _PresetGroup group(int i) => _presets[i];
+  static int numItemsInGroup(int i) => _presets[i].items.length;
+
+  static Scene makeScene(int groupIndex, int sceneIndex) {
+    return _presets[groupIndex].items[sceneIndex]();
+  }
 
   //# region Individual presets
 

--- a/sandbox/lib/presets.dart
+++ b/sandbox/lib/presets.dart
@@ -53,6 +53,7 @@ class _PresetGroup {
 
 class _PresetItem {
   const _PresetItem(this.name, this.maker);
+
   final String name;
   final Scene Function() maker;
 

--- a/sandbox/lib/widgets/left_menu.dart
+++ b/sandbox/lib/widgets/left_menu.dart
@@ -9,7 +9,8 @@ class LeftMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final n = kPresets.length;
+    final group = Presets.group(app.currentGroup!);
+    final n = group.items.length;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
       child: Column(

--- a/sandbox/lib/widgets/left_menu.dart
+++ b/sandbox/lib/widgets/left_menu.dart
@@ -9,8 +9,6 @@ class LeftMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final group = Presets.group(app.currentGroup!);
-    final n = group.items.length;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
       child: Column(
@@ -21,9 +19,6 @@ class LeftMenu extends StatelessWidget {
               'Presets',
               textAlign: TextAlign.left,
               style: Theme.of(context).primaryTextTheme.headline6,
-              // TextStyle(color: Theme.of(context).primaryColor,
-              //   fontSize: Theme.of(context).primaryTextTheme.
-              // ),
             ),
           ),
           Padding(
@@ -34,7 +29,9 @@ class LeftMenu extends StatelessWidget {
                 fontSize: 14,
               ),
               child: Column(
-                children: List.generate(n, (i) => _ListItem(i, app)),
+                children: List.generate(
+                    Presets.numGroups, (i) => _ListHeader(app, i),
+                ),
               ),
             ),
           ),
@@ -44,11 +41,46 @@ class LeftMenu extends StatelessWidget {
   }
 }
 
-class _ListItem extends StatefulWidget {
-  const _ListItem(this.index, this.app);
+class _ListHeader extends StatelessWidget {
+  const _ListHeader(this.app, this.groupIndex);
 
-  final int index;
   final SandboxState app;
+  final int groupIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = Presets.group(groupIndex).name;
+    final isOpen = app.groupOpen[groupIndex];
+    Widget result = MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: Row(
+        children: [
+          Icon(isOpen ? Icons.arrow_right : Icons.arrow_drop_down),
+          Text(title),
+        ],
+      ),
+    );
+    if (isOpen) {
+      final n = Presets.numItemsInGroup(groupIndex);
+      final groupIsCurrent = app.currentGroup == groupIndex;
+      result = Column(
+        children: [
+          result,
+          for (var i = 0; i < n; i++)
+            _ListItem(groupIndex, i, groupIsCurrent && i == app.currentPreset)
+        ],
+      );
+    }
+    return result;
+  }
+}
+
+class _ListItem extends StatefulWidget {
+  const _ListItem(this.groupIndex, this.itemIndex, this.isCurrent);
+
+  final int groupIndex;
+  final int itemIndex;
+  final bool isCurrent;
 
   @override
   State createState() => _ListItemState();
@@ -63,7 +95,6 @@ class _ListItemState extends State<_ListItem> {
 
   @override
   Widget build(BuildContext context) {
-    final isCurrent = widget.app.currentPreset == widget.index;
     return MouseRegion(
       onEnter: _mouseEnter,
       onExit: _mouseLeave,
@@ -75,8 +106,8 @@ class _ListItemState extends State<_ListItem> {
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
             child: Text(
-              widget.app.currentScene.name,
-              style: isCurrent ? styleWhenCurrent : null,
+              Presets.sceneName(widget.groupIndex, widget.itemIndex),
+              style: widget.isCurrent ? styleWhenCurrent : null,
             ),
           ),
         ),

--- a/sandbox/lib/widgets/left_menu.dart
+++ b/sandbox/lib/widgets/left_menu.dart
@@ -50,7 +50,7 @@ class _ListHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final title = Presets.group(groupIndex).name;
-    final isOpen = app.groupOpen[groupIndex];
+    final isOpen = app.openGroups[groupIndex];
     Widget result = MouseRegion(
       cursor: SystemMouseCursors.click,
       child: Row(

--- a/sandbox/lib/widgets/left_menu.dart
+++ b/sandbox/lib/widgets/left_menu.dart
@@ -72,7 +72,6 @@ class _ListHeader extends StatelessWidget {
     );
     if (isOpen) {
       final n = Presets.numItemsInGroup(groupIndex);
-      final groupIsCurrent = app.currentGroup == groupIndex;
       result = Column(
         children: [
           result,
@@ -81,11 +80,7 @@ class _ListHeader extends StatelessWidget {
             child: Column(
               children: [
                 for (var itemIndex = 0; itemIndex < n; itemIndex++)
-                  _ListItem(
-                    groupIndex,
-                    itemIndex,
-                    groupIsCurrent && itemIndex == app.currentPreset,
-                  )
+                  _ListItem(groupIndex, itemIndex, app)
               ],
             ),
           ),
@@ -101,11 +96,15 @@ class _ListHeader extends StatelessWidget {
 }
 
 class _ListItem extends StatefulWidget {
-  const _ListItem(this.groupIndex, this.itemIndex, this.isCurrent);
+  const _ListItem(this.groupIndex, this.itemIndex, this.app);
 
   final int groupIndex;
   final int itemIndex;
-  final bool isCurrent;
+  final SandboxState app;
+
+  bool get isCurrent {
+    return app.currentGroup == groupIndex && app.currentPreset == itemIndex;
+  }
 
   @override
   State createState() => _ListItemState();
@@ -123,19 +122,22 @@ class _ListItemState extends State<_ListItem> {
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      onEnter: _mouseEnter,
-      onExit: _mouseLeave,
-      cursor: SystemMouseCursors.click,
-      child: SizedBox(
-        width: double.infinity,
-        child: Container(
-          color: Color.fromRGBO(255, 255, 255, _hover ? 0.1 : 0),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
-            child: Text(
-              Presets.sceneName(widget.groupIndex, widget.itemIndex),
-              style: widget.isCurrent ? styleWhenCurrent : styleNormal,
+    return GestureDetector(
+      onTap: _handleTap,
+      child: MouseRegion(
+        onEnter: _mouseEnter,
+        onExit: _mouseLeave,
+        cursor: SystemMouseCursors.click,
+        child: SizedBox(
+          width: double.infinity,
+          child: Container(
+            color: Color.fromRGBO(255, 255, 255, _hover ? 0.1 : 0),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+              child: Text(
+                Presets.sceneName(widget.groupIndex, widget.itemIndex),
+                style: widget.isCurrent ? styleWhenCurrent : styleNormal,
+              ),
             ),
           ),
         ),
@@ -149,5 +151,9 @@ class _ListItemState extends State<_ListItem> {
 
   void _mouseLeave(PointerEvent details) {
     setState(() => _hover = false);
+  }
+
+  void _handleTap() {
+    widget.app.selectPreset(widget.groupIndex, widget.itemIndex);
   }
 }

--- a/sandbox/lib/widgets/left_menu.dart
+++ b/sandbox/lib/widgets/left_menu.dart
@@ -13,6 +13,7 @@ class LeftMenu extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
       child: Column(
         children: [
+          // "Presets" header
           SizedBox(
             width: double.infinity,
             child: Text(
@@ -22,7 +23,7 @@ class LeftMenu extends StatelessWidget {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(10, 10, 0, 0),
+            padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
             child: DefaultTextStyle(
               style: const TextStyle(
                 color: Color(0xFFBBBBBB),
@@ -30,7 +31,8 @@ class LeftMenu extends StatelessWidget {
               ),
               child: Column(
                 children: List.generate(
-                    Presets.numGroups, (i) => _ListHeader(app, i),
+                  Presets.numGroups,
+                  (i) => _ListHeader(app, i),
                 ),
               ),
             ),
@@ -51,13 +53,21 @@ class _ListHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final title = Presets.group(groupIndex).name;
     final isOpen = app.openGroups[groupIndex];
-    Widget result = MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: Row(
-        children: [
-          Icon(isOpen ? Icons.arrow_right : Icons.arrow_drop_down),
-          Text(title),
-        ],
+    Widget result = GestureDetector(
+      onTap: _handleTap,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: Row(
+          children: [
+            Icon(isOpen ? Icons.arrow_drop_down : Icons.arrow_right),
+            Text(
+              title,
+              style: const TextStyle(
+                color: Colors.white,
+              ),
+            ),
+          ],
+        ),
       ),
     );
     if (isOpen) {
@@ -66,12 +76,27 @@ class _ListHeader extends StatelessWidget {
       result = Column(
         children: [
           result,
-          for (var i = 0; i < n; i++)
-            _ListItem(groupIndex, i, groupIsCurrent && i == app.currentPreset)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(30, 0, 0, 10),
+            child: Column(
+              children: [
+                for (var itemIndex = 0; itemIndex < n; itemIndex++)
+                  _ListItem(
+                    groupIndex,
+                    itemIndex,
+                    groupIsCurrent && itemIndex == app.currentPreset,
+                  )
+              ],
+            ),
+          ),
         ],
       );
     }
     return result;
+  }
+
+  void _handleTap() {
+    app.toggleGroup(groupIndex);
   }
 }
 
@@ -88,8 +113,11 @@ class _ListItem extends StatefulWidget {
 
 class _ListItemState extends State<_ListItem> {
   static const styleWhenCurrent = TextStyle(
-    fontWeight: FontWeight.bold,
     color: Colors.white,
+    fontSize: 12,
+  );
+  static const styleNormal = TextStyle(
+    fontSize: 12,
   );
   bool _hover = false;
 
@@ -107,7 +135,7 @@ class _ListItemState extends State<_ListItem> {
             padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
             child: Text(
               Presets.sceneName(widget.groupIndex, widget.itemIndex),
-              style: widget.isCurrent ? styleWhenCurrent : null,
+              style: widget.isCurrent ? styleWhenCurrent : styleNormal,
             ),
           ),
         ),


### PR DESCRIPTION
We want to be able to have multiple examples for each behavior type, so a hierarchical menu seems appropriate.