### PR TITLE
chore!: Rename Kinematics classes

### DIFF
--- a/lib/src/steering/behaviors/flee.dart
+++ b/lib/src/steering/behaviors/flee.dart
@@ -2,8 +2,8 @@ import 'package:vector_math/vector_math_64.dart' show Vector2;
 
 import '../../options/angles.dart';
 import '../behavior.dart';
-import '../kinematics/max_acceleration_kinematics.dart';
-import '../kinematics/max_speed_kinematics.dart';
+import '../kinematics/heavy_kinematics.dart';
+import '../kinematics/light_kinematics.dart';
 import '../steerable.dart';
 
 /// [Flee] behavior forces the owner to move as far away and as fast as possible
@@ -58,31 +58,31 @@ abstract class Flee extends Behavior {
   }
 }
 
-/// [Flee] behavior for [MaxSpeedKinematics].
-class FleeAtMaxSpeed extends Flee {
-  FleeAtMaxSpeed({required Steerable owner, required List<Vector2> targets})
-      : assert(owner.kinematics is MaxSpeedKinematics),
+/// [Flee] behavior for [LightKinematics].
+class FleeLight extends Flee {
+  FleeLight({required Steerable owner, required List<Vector2> targets})
+      : assert(owner.kinematics is LightKinematics),
         super._(owner, targets);
 
   @override
   void update(double dt) {
-    final kinematics = own.kinematics as MaxSpeedKinematics;
+    final kinematics = own.kinematics as LightKinematics;
     final steering = fleeDirection..scale(kinematics.maxSpeed);
     kinematics.setVelocity(steering);
   }
 }
 
-/// [Flee] behavior for objects with [MaxAccelerationKinematics].
-class FleeForMaxAcceleration extends Flee {
-  FleeForMaxAcceleration({
+/// [Flee] behavior for objects with [HeavyKinematics].
+class FleeHeavy extends Flee {
+  FleeHeavy({
     required Steerable owner,
     required List<Vector2> targets,
-  })  : assert(owner.kinematics is MaxAccelerationKinematics),
+  })  : assert(owner.kinematics is HeavyKinematics),
         super._(owner, targets);
 
   @override
   void update(double dt) {
-    final kinematics = own.kinematics as MaxAccelerationKinematics;
+    final kinematics = own.kinematics as HeavyKinematics;
     final steering = fleeDirection..scale(kinematics.maxAcceleration);
     kinematics.setAcceleration(steering);
   }

--- a/lib/src/steering/behaviors/seek.dart
+++ b/lib/src/steering/behaviors/seek.dart
@@ -3,8 +3,8 @@ import 'dart:math';
 import 'package:vector_math/vector_math_64.dart';
 
 import '../behavior.dart';
-import '../kinematics/max_acceleration_kinematics.dart';
-import '../kinematics/max_speed_kinematics.dart';
+import '../kinematics/heavy_kinematics.dart';
+import '../kinematics/light_kinematics.dart';
 import '../steerable.dart';
 
 /// [Seek] behavior acts to move the agent towards the specified static point.
@@ -32,15 +32,15 @@ abstract class Seek extends Behavior {
   final Vector2 target;
 }
 
-/// [Seek] behavior for objects that have [MaxSpeedKinematics].
-class SeekAtMaxSpeed extends Seek {
-  SeekAtMaxSpeed({required Steerable owner, required Vector2 point})
-      : assert(owner.kinematics is MaxSpeedKinematics),
+/// [Seek] behavior for objects that have [LightKinematics].
+class SeekLight extends Seek {
+  SeekLight({required Steerable owner, required Vector2 point})
+      : assert(owner.kinematics is LightKinematics),
         super._(owner, point);
 
   @override
   void update(double dt) {
-    final kinematics = own.kinematics as MaxSpeedKinematics;
+    final kinematics = own.kinematics as LightKinematics;
     final offset = target - own.position;
     final distance = offset.normalize();
     var maxSpeed = kinematics.maxSpeed;
@@ -51,15 +51,15 @@ class SeekAtMaxSpeed extends Seek {
   }
 }
 
-/// [Seek] behavior for objects with [MaxAccelerationKinematics].
-class SeekForMaxAcceleration extends Seek {
-  SeekForMaxAcceleration({required Steerable owner, required Vector2 point})
-      : assert(owner.kinematics is MaxAccelerationKinematics),
+/// [Seek] behavior for objects with [HeavyKinematics].
+class SeekHeavy extends Seek {
+  SeekHeavy({required Steerable owner, required Vector2 point})
+      : assert(owner.kinematics is HeavyKinematics),
         super._(owner, point);
 
   @override
   void update(double dt) {
-    final kinematics = own.kinematics as MaxAccelerationKinematics;
+    final kinematics = own.kinematics as HeavyKinematics;
     final offset = target - own.position;
     final targetVelocity = offset..length = kinematics.maxSpeed;
     final velocityDelta = targetVelocity - own.velocity;

--- a/lib/src/steering/kinematics/heavy_kinematics.dart
+++ b/lib/src/steering/kinematics/heavy_kinematics.dart
@@ -4,7 +4,7 @@ import '../behaviors/flee.dart';
 import '../behaviors/seek.dart';
 import '../kinematics.dart';
 
-/// [MaxAccelerationKinematics] describes an agent who can move in any direction
+/// [HeavyKinematics] describes an agent who can move in any direction
 /// with speed up to `maxSpeed`, and change their velocity with acceleration
 /// not exceeding `maxAcceleration`. This acceleration can be applied equally
 /// in all directions, regardless of the direction where the character is
@@ -13,8 +13,8 @@ import '../kinematics.dart';
 /// This kinematics model is described by Craig Reynolds in his 1999 report on
 /// steering behaviors, and is considered "standard" for game AI. It produces
 /// reasonably looking behaviors and can be used in a variety of situations.
-class MaxAccelerationKinematics extends Kinematics {
-  MaxAccelerationKinematics({
+class HeavyKinematics extends Kinematics {
+  HeavyKinematics({
     required double maxSpeed,
     required double maxAcceleration,
   })  : assert(maxSpeed > 0, 'maxSpeed must be positive'),
@@ -58,12 +58,10 @@ class MaxAccelerationKinematics extends Kinematics {
   }
 
   @override
-  Seek seek(Vector2 point) => SeekForMaxAcceleration(owner: own, point: point);
+  Seek seek(Vector2 point) => SeekHeavy(owner: own, point: point);
 
   @override
   Flee flee(List<Vector2> targets) {
-    return FleeForMaxAcceleration(owner: own, targets: targets);
+    return FleeHeavy(owner: own, targets: targets);
   }
 }
-
-typedef HeavyKinematics = MaxAccelerationKinematics;

--- a/lib/src/steering/kinematics/light_kinematics.dart
+++ b/lib/src/steering/kinematics/light_kinematics.dart
@@ -4,14 +4,14 @@ import '../behaviors/flee.dart';
 import '../behaviors/seek.dart';
 import 'basic_kinematics.dart';
 
-/// [MaxSpeedKinematics] describes a character who can move freely in any
+/// [LightKinematics] describes a character who can move freely in any
 /// direction with speeds up to `maxSpeed`, and change their velocity
 /// instantaneously with no regard to inertia.
 ///
-/// Use this for very small creatures like ants, or in situations where physical
-/// realism is not needed.
-class MaxSpeedKinematics extends BasicKinematics {
-  MaxSpeedKinematics(this._maxSpeed)
+/// Use this for small lightweight creatures, like ants, or in situations where
+/// physical realism is not needed.
+class LightKinematics extends BasicKinematics {
+  LightKinematics(this._maxSpeed)
       : assert(_maxSpeed > 0, 'maxSpeed must be positive');
 
   double get maxSpeed => _maxSpeed;
@@ -42,11 +42,8 @@ class MaxSpeedKinematics extends BasicKinematics {
   }
 
   @override
-  Seek seek(Vector2 target) => SeekAtMaxSpeed(owner: own, point: target);
+  Seek seek(Vector2 target) => SeekLight(owner: own, point: target);
 
   @override
-  Flee flee(List<Vector2> targets) =>
-      FleeAtMaxSpeed(owner: own, targets: targets);
+  Flee flee(List<Vector2> targets) => FleeLight(owner: own, targets: targets);
 }
-
-typedef LightKinematics = MaxSpeedKinematics;

--- a/lib/steering.dart
+++ b/lib/steering.dart
@@ -8,10 +8,8 @@ export 'src/options/angles.dart' show angleToVector, vectorToAngle;
 
 // Kinematics implementations
 export 'src/steering/kinematics/basic_kinematics.dart' show BasicKinematics;
-export 'src/steering/kinematics/max_acceleration_kinematics.dart'
-    show MaxAccelerationKinematics, HeavyKinematics;
-export 'src/steering/kinematics/max_speed_kinematics.dart'
-    show MaxSpeedKinematics, LightKinematics;
+export 'src/steering/kinematics/heavy_kinematics.dart' show HeavyKinematics;
+export 'src/steering/kinematics/light_kinematics.dart' show LightKinematics;
 
 // Behaviors
 export 'src/steering/behaviors/flee.dart' show Flee;

--- a/sandbox/lib/entities/heavy_entity.dart
+++ b/sandbox/lib/entities/heavy_entity.dart
@@ -6,8 +6,8 @@ import 'package:vector_math/vector_math_64.dart';
 
 import 'entity.dart';
 
-class MaxAccelerationEntity extends Entity {
-  MaxAccelerationEntity({
+class HeavyEntity extends Entity {
+  HeavyEntity({
     Vector2? position,
     Vector2? velocity,
     required double maxSpeed,
@@ -17,7 +17,7 @@ class MaxAccelerationEntity extends Entity {
           position: position,
           size: size,
           velocity: velocity,
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: maxSpeed,
             maxAcceleration: maxAcceleration,
           ),

--- a/sandbox/lib/presets.dart
+++ b/sandbox/lib/presets.dart
@@ -1,7 +1,7 @@
 import 'package:radiance/steering.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'entities/max_acceleration_entity.dart';
+import 'entities/heavy_entity.dart';
 import 'entities/static_target_entity.dart';
 import 'scene.dart';
 
@@ -29,7 +29,7 @@ class Presets {
   static Scene _seek1() {
     final p = Scene('Heavy');
     final target = StaticTargetEntity(position: Vector2(60, 30));
-    final predator = MaxAccelerationEntity(
+    final predator = HeavyEntity(
       position: Vector2(-40, -40),
       velocity: Vector2(-10, 10),
       maxSpeed: 25,

--- a/test/steering/behaviors/flee_test.dart
+++ b/test/steering/behaviors/flee_test.dart
@@ -10,7 +10,7 @@ void main() {
   group('Flee', () {
     group('common', () {
       test('errors', () {
-        final agent = SimpleSteerable(kinematics: MaxSpeedKinematics(10));
+        final agent = SimpleSteerable(kinematics: LightKinematics(10));
         expect(
           () => Flee(owner: agent, targets: []),
           throws<AssertionError>('The list of targets to Flee cannot be empty'),
@@ -23,7 +23,7 @@ void main() {
         List<Vector2> targets, {
         double orientation = 0,
       }) {
-        final agent = SimpleSteerable(kinematics: MaxSpeedKinematics(10));
+        final agent = SimpleSteerable(kinematics: LightKinematics(10));
         agent.angle = orientation;
         final behavior = Flee(owner: agent, targets: targets);
         expect(agent.position, closeToVector(0, 0));
@@ -60,7 +60,7 @@ void main() {
 
     group(':MaxSpeedKinematics', () {
       test('properties', () {
-        final agent = SimpleSteerable(kinematics: MaxSpeedKinematics(10));
+        final agent = SimpleSteerable(kinematics: LightKinematics(10));
         final behavior = Flee(owner: agent, targets: [Vector2(20, 10)]);
         expect(behavior.own, agent);
         expect(behavior.targets.length, 1);
@@ -71,7 +71,7 @@ void main() {
         final distance = fleeDistance(
           initialPosition: Vector2(5, 0),
           initialVelocity: Vector2.zero(),
-          kinematics: MaxSpeedKinematics(10),
+          kinematics: LightKinematics(10),
           duration: 10,
         );
         expect(distance, closeTo(105, 0.1));
@@ -81,7 +81,7 @@ void main() {
         final distance = fleeDistance(
           initialPosition: Vector2(12, -10),
           initialVelocity: Vector2(3, 5),
-          kinematics: MaxSpeedKinematics(10),
+          kinematics: LightKinematics(10),
         );
         expect(distance, closeTo(1015.62, 0.01));
       });
@@ -90,7 +90,7 @@ void main() {
         final distance = fleeDistance(
           initialPosition: Vector2(0, 0.01),
           initialVelocity: Vector2.zero(),
-          kinematics: MaxSpeedKinematics(10),
+          kinematics: LightKinematics(10),
           targets: [Vector2(10, 0), Vector2(-10, 3), Vector2(-10, -3)],
         );
         expect(distance, closeTo(999.71, 0.01));
@@ -101,7 +101,7 @@ void main() {
         final distance = fleeDistance(
           initialPosition: Vector2(0.02, 0.01),
           initialVelocity: Vector2.zero(),
-          kinematics: MaxSpeedKinematics(10),
+          kinematics: LightKinematics(10),
           targets: [
             Vector2(10, 0),
             Vector2(-10, 0),
@@ -122,7 +122,7 @@ void main() {
         final distance = fleeDistance(
           initialPosition: Vector2.zero(),
           initialVelocity: Vector2.zero(),
-          kinematics: MaxSpeedKinematics(10),
+          kinematics: LightKinematics(10),
           targets: [Vector2(10, 0), Vector2(-10, 4), Vector2(-10, -4)],
         );
         expect(distance, closeTo(6.33, 0.01));
@@ -132,7 +132,7 @@ void main() {
     group(':MaxAccelerationKinematics', () {
       test('properties', () {
         final agent = SimpleSteerable(
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: 20,
             maxAcceleration: 15,
           ),
@@ -151,7 +151,7 @@ void main() {
         final distance = fleeDistance(
           initialPosition: Vector2(x0, 0),
           initialVelocity: Vector2.zero(),
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: vMax,
             maxAcceleration: aMax,
           ),
@@ -167,7 +167,7 @@ void main() {
         final distance = fleeDistance(
           initialPosition: Vector2(12, -10),
           initialVelocity: Vector2(3, 5),
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: 10,
             maxAcceleration: 5,
           ),
@@ -179,7 +179,7 @@ void main() {
         final distance = fleeDistance(
           initialPosition: Vector2(0, 0.01),
           initialVelocity: Vector2.zero(),
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: 10,
             maxAcceleration: 5,
           ),
@@ -192,7 +192,7 @@ void main() {
         final distance = fleeDistance(
           initialPosition: Vector2(0.02, 0.01),
           initialVelocity: Vector2.zero(),
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: 10,
             maxAcceleration: 5,
           ),

--- a/test/steering/behaviors/seek_test.dart
+++ b/test/steering/behaviors/seek_test.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
 
 import 'package:radiance/src/steering/behaviors/seek.dart';
-import 'package:radiance/src/steering/kinematics/max_acceleration_kinematics.dart';
-import 'package:radiance/src/steering/kinematics/max_speed_kinematics.dart';
+import 'package:radiance/src/steering/kinematics/heavy_kinematics.dart';
+import 'package:radiance/src/steering/kinematics/light_kinematics.dart';
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
@@ -14,7 +14,7 @@ void main() {
   group('Seek', () {
     group(':MaxSpeedKinematics', () {
       test('properties', () {
-        final agent = SimpleSteerable(kinematics: MaxSpeedKinematics(10));
+        final agent = SimpleSteerable(kinematics: LightKinematics(10));
         final behavior = Seek(owner: agent, point: Vector2(20, 50));
 
         expect(behavior.own, agent);
@@ -36,7 +36,7 @@ void main() {
         final seeker = SimpleSteerable(
           velocity: Vector2.random() * maxSpeed,
           position: origin,
-          kinematics: MaxSpeedKinematics(maxSpeed),
+          kinematics: LightKinematics(maxSpeed),
         );
         seeker.behavior = Seek(owner: seeker, point: target);
 
@@ -56,7 +56,7 @@ void main() {
     group(':MaxAccelerationKinematics', () {
       test('properties', () {
         final agent = SimpleSteerable(
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: 10,
             maxAcceleration: 20,
           ),
@@ -76,7 +76,7 @@ void main() {
         final agent = SimpleSteerable(
           position: Vector2.zero(),
           velocity: Vector2.zero(),
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: 1000,
             maxAcceleration: acceleration,
           ),
@@ -103,7 +103,7 @@ void main() {
         final seeker = SimpleSteerable(
           velocity: Vector2.random() * maxSpeed,
           position: origin,
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: maxSpeed,
             maxAcceleration: acceleration,
           ),
@@ -134,7 +134,7 @@ void main() {
         final seeker = SimpleSteerable(
           velocity: initialVelocity,
           position: initialPosition,
-          kinematics: MaxAccelerationKinematics(
+          kinematics: HeavyKinematics(
             maxSpeed: maxSpeed,
             maxAcceleration: maxAcceleration,
           ),

--- a/test/steering/kinematics/heavy_kinematics_test.dart
+++ b/test/steering/kinematics/heavy_kinematics_test.dart
@@ -75,14 +75,14 @@ void main() {
       final kinematics = HeavyKinematics(maxSpeed: 5, maxAcceleration: 3);
       final agent = SimpleSteerable(kinematics: kinematics);
       final seek = agent.kinematics.seek(Vector2.zero());
-      expect(seek, isA<SeekForMaxAcceleration>());
+      expect(seek, isA<SeekHeavy>());
     });
 
     test('flee', () {
       final kinematics = HeavyKinematics(maxSpeed: 5, maxAcceleration: 3);
       final agent = SimpleSteerable(kinematics: kinematics);
       final flee = agent.kinematics.flee([Vector2.zero()]);
-      expect(flee, isA<FleeForMaxAcceleration>());
+      expect(flee, isA<FleeHeavy>());
     });
   });
 }

--- a/test/steering/kinematics/light_kinematics_test.dart
+++ b/test/steering/kinematics/light_kinematics_test.dart
@@ -76,13 +76,13 @@ void main() {
     test('seek', () {
       final agent = SimpleSteerable(kinematics: LightKinematics(10));
       final seek = agent.kinematics.seek(Vector2.zero());
-      expect(seek, isA<SeekAtMaxSpeed>());
+      expect(seek, isA<SeekLight>());
     });
 
     test('flee', () {
       final agent = SimpleSteerable(kinematics: LightKinematics(10));
       final flee = agent.kinematics.flee([Vector2.zero()]);
-      expect(flee, isA<FleeAtMaxSpeed>());
+      expect(flee, isA<FleeLight>());
     });
   });
 }


### PR DESCRIPTION
Rename `MaxSpeedKinematics` -> `LightKinematics` and `MaxAccelerationKinematics` -> `HeavyKinematics`. This makes the names closer to the other kinematics classes that we plan to add in the future: `PedalKinematics`, `CarKinematics`, `RobotKinematics`.