### PR TITLE
feat: Add display of velocity/acceleration vectors in sandbox

### DIFF
--- a/lib/src/steering/kinematics.dart
+++ b/lib/src/steering/kinematics.dart
@@ -20,6 +20,9 @@ import 'steerable.dart';
 /// The method `handleAttach()` must be called by the user when the kinematics
 /// object is attached to a concrete [Steerable].
 abstract class Kinematics {
+  /// Returns a copy of this kinematics object, except for the [own] field.
+  Kinematics clone();
+
   /// Reference to the object being steered.
   ///
   /// This variable will be set within the `handleAttach()` method, and will

--- a/lib/src/steering/kinematics/basic_kinematics.dart
+++ b/lib/src/steering/kinematics/basic_kinematics.dart
@@ -5,6 +5,9 @@ import '../kinematics.dart';
 /// values.
 class BasicKinematics extends Kinematics {
   @override
+  BasicKinematics clone() => BasicKinematics();
+
+  @override
   void update(double dt) {
     own.position.x += own.velocity.x * dt;
     own.position.y += own.velocity.y * dt;

--- a/lib/src/steering/kinematics/heavy_kinematics.dart
+++ b/lib/src/steering/kinematics/heavy_kinematics.dart
@@ -42,7 +42,7 @@ class HeavyKinematics extends Kinematics {
     return HeavyKinematics(
       maxSpeed: _maxSpeed,
       maxAcceleration: _maxAcceleration,
-    ) ..setAcceleration(_acceleration);
+    )..setAcceleration(_acceleration);
   }
 
   /// Acceleration that will be applied to the owner on the next tick.

--- a/lib/src/steering/kinematics/heavy_kinematics.dart
+++ b/lib/src/steering/kinematics/heavy_kinematics.dart
@@ -37,8 +37,17 @@ class HeavyKinematics extends Kinematics {
     _maxAcceleration = value;
   }
 
-  final Vector2 _acceleration;
+  @override
+  HeavyKinematics clone() {
+    return HeavyKinematics(
+      maxSpeed: _maxSpeed,
+      maxAcceleration: _maxAcceleration,
+    ) ..setAcceleration(_acceleration);
+  }
 
+  /// Acceleration that will be applied to the owner on the next tick.
+  Vector2 get acceleration => _acceleration;
+  final Vector2 _acceleration;
   void setAcceleration(Vector2 value) {
     assert(
       value.length2 <= maxAcceleration * maxAcceleration * (1 + 1e-8),

--- a/lib/src/steering/kinematics/light_kinematics.dart
+++ b/lib/src/steering/kinematics/light_kinematics.dart
@@ -21,6 +21,9 @@ class LightKinematics extends BasicKinematics {
     _maxSpeed = value;
   }
 
+  @override
+  LightKinematics clone() => LightKinematics(_maxSpeed);
+
   void stop() {
     own.velocity.setZero();
   }

--- a/sandbox/lib/entities/entity.dart
+++ b/sandbox/lib/entities/entity.dart
@@ -40,10 +40,14 @@ abstract class Entity implements Steerable {
 
   Behavior? behavior;
 
+  Entity clone();
+
   void render(Canvas canvas);
 
   void update(double dt) {
     behavior?.update(dt);
     kinematics.update(dt);
   }
+
+  List<Vector2> get vectors;
 }

--- a/sandbox/lib/entities/entity.dart
+++ b/sandbox/lib/entities/entity.dart
@@ -41,7 +41,6 @@ abstract class Entity implements Steerable {
   Behavior? behavior;
 
   void render(Canvas canvas);
-  void renderVectors(Canvas canvas);
 
   void update(double dt) {
     behavior?.update(dt);

--- a/sandbox/lib/entities/heavy_entity.dart
+++ b/sandbox/lib/entities/heavy_entity.dart
@@ -48,6 +48,7 @@ class HeavyEntity extends Entity {
     canvas.restore();
   }
 
-  @override
-  void renderVectors(Canvas canvas) {}
+  List<Vector2> get vectors {
+    return [position, velocity, (kinematics as HeavyKinematics).acceleration];
+  }
 }

--- a/sandbox/lib/entities/heavy_entity.dart
+++ b/sandbox/lib/entities/heavy_entity.dart
@@ -39,6 +39,17 @@ class HeavyEntity extends Entity {
   late final Paint outlinePaint;
 
   @override
+  HeavyEntity clone() {
+    return HeavyEntity(
+      position: position,
+      velocity: velocity,
+      maxSpeed: (kinematics as HeavyKinematics).maxSpeed,
+      maxAcceleration: (kinematics as HeavyKinematics).maxAcceleration,
+      size: size,
+    );
+  }
+
+  @override
   void render(Canvas canvas) {
     canvas.save();
     canvas.translate(position.x, position.y);
@@ -48,7 +59,8 @@ class HeavyEntity extends Entity {
     canvas.restore();
   }
 
+  @override
   List<Vector2> get vectors {
-    return [position, velocity, (kinematics as HeavyKinematics).acceleration];
+    return [velocity, (kinematics as HeavyKinematics).acceleration];
   }
 }

--- a/sandbox/lib/entities/static_entity.dart
+++ b/sandbox/lib/entities/static_entity.dart
@@ -3,10 +3,9 @@ import 'dart:ui';
 import 'package:vector_math/vector_math_64.dart' hide Vector;
 
 import 'entity.dart';
-import 'vector_visual.dart';
 
-class StaticTargetEntity extends Entity {
-  StaticTargetEntity({Vector2? position, double size = 5})
+class StaticEntity extends Entity {
+  StaticEntity({Vector2? position, double size = 5})
       : super(position: position, size: size) {
     final a = size / 6;
     path = Path()
@@ -28,6 +27,11 @@ class StaticTargetEntity extends Entity {
   late final Paint paint;
 
   @override
+  StaticEntity clone() {
+    return StaticEntity(position: position, size: size);
+  }
+
+  @override
   void render(Canvas canvas) {
     canvas.save();
     canvas.translate(position.x, position.y);
@@ -36,7 +40,5 @@ class StaticTargetEntity extends Entity {
   }
 
   @override
-  void renderVectors(Canvas canvas) {
-    VectorVisual(position, velocity).render(canvas);
-  }
+  List<Vector2> get vectors => [];
 }

--- a/sandbox/lib/entities/vector_visual.dart
+++ b/sandbox/lib/entities/vector_visual.dart
@@ -5,7 +5,7 @@ import 'package:vector_math/vector_math_64.dart';
 
 class VectorVisual {
   VectorVisual(this.origin, this.vector, this.styleIndex)
-    : assert(styleIndex < lineStyles.length);
+      : assert(styleIndex < lineStyles.length);
 
   final Vector2 origin;
   final Vector2 vector;
@@ -22,8 +22,8 @@ class VectorVisual {
       ..color = const Color(0xff5ed9ff),
   ];
   static List<Paint> arrowStyles = [
-    Paint() ..color = const Color(0xffffc655),
-    Paint() ..color = const Color(0xff5ed9ff),
+    Paint()..color = const Color(0xffffc655),
+    Paint()..color = const Color(0xff5ed9ff),
   ];
   static const arrowLength = 3.0;
 

--- a/sandbox/lib/entities/vector_visual.dart
+++ b/sandbox/lib/entities/vector_visual.dart
@@ -1,28 +1,49 @@
 import 'dart:ui';
 
+import 'package:flutter/material.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 class VectorVisual {
-  VectorVisual(this.origin, this.vector);
+  VectorVisual(this.origin, this.vector, this.styleIndex)
+    : assert(styleIndex < lineStyles.length);
 
   final Vector2 origin;
   final Vector2 vector;
-  final Paint paint = Paint()..style = PaintingStyle.stroke;
-  final double arrowHalfWidth = 0.5;
-  final double arrowLength = 3;
+  final int styleIndex;
+
+  static List<Paint> lineStyles = [
+    Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.2
+      ..color = const Color(0xffffc655),
+    Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.4
+      ..color = const Color(0xff5ed9ff),
+  ];
+  static List<Paint> arrowStyles = [
+    Paint() ..color = const Color(0xffffc655),
+    Paint() ..color = const Color(0xff5ed9ff),
+  ];
+  static const arrowLength = 3.0;
 
   void render(Canvas canvas) {
     final path = Path();
     path.moveTo(origin.x, origin.y);
     path.relativeLineTo(vector.x, vector.y);
+    canvas.drawPath(path, lineStyles[styleIndex]);
     if (vector.length >= arrowLength * 1.5) {
       final normal = vector.normalized();
       final arrowBase = normal.scaled(arrowLength);
+      final arrowHalfWidth = lineStyles[styleIndex].strokeWidth * 2;
       normal.scaleOrthogonalInto(arrowHalfWidth, normal);
+      path.reset();
+      path.moveTo(origin.x + vector.x, origin.y + vector.y);
       path.relativeLineTo(-arrowBase.x + normal.x, -arrowBase.y + normal.y);
       path.relativeLineTo(-normal.x * 2, -normal.y * 2);
-      path.close();
+      path.relativeLineTo(arrowBase.x + normal.x, arrowBase.y + normal.y);
+      canvas.drawPath(path, arrowStyles[styleIndex]);
+      // path.close();
     }
-    canvas.drawPath(path, paint);
   }
 }

--- a/sandbox/lib/main.dart
+++ b/sandbox/lib/main.dart
@@ -60,6 +60,8 @@ class SandboxState extends State<_MyApp> {
   /// preset selected, this will be `null`.
   int? currentPreset;
 
+  bool showVectors = false;
+
   late Scene currentScene;
 
   EngineState engineState = EngineState.running;
@@ -75,6 +77,13 @@ class SandboxState extends State<_MyApp> {
   void toggleGroup(int groupIndex) {
     setState(() {
       openGroups[groupIndex] = !openGroups[groupIndex];
+    });
+  }
+
+  void toggleVectors() {
+    setState(() {
+      showVectors = !showVectors;
+      currentScene.toggleVectors(showVectors);
     });
   }
 

--- a/sandbox/lib/presets.dart
+++ b/sandbox/lib/presets.dart
@@ -2,7 +2,7 @@ import 'package:radiance/steering.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'entities/heavy_entity.dart';
-import 'entities/static_target_entity.dart';
+import 'entities/static_entity.dart';
 import 'scene.dart';
 
 class Presets {
@@ -28,7 +28,7 @@ class Presets {
 
   static Scene _seek1() {
     final p = Scene('Heavy');
-    final target = StaticTargetEntity(position: Vector2(60, 30));
+    final target = StaticEntity(position: Vector2(60, 30));
     final predator = HeavyEntity(
       position: Vector2(-40, -40),
       velocity: Vector2(-10, 10),

--- a/sandbox/lib/scene.dart
+++ b/sandbox/lib/scene.dart
@@ -1,12 +1,14 @@
 import 'dart:ui';
 
 import 'entities/entity.dart';
+import 'entities/vector_visual.dart';
 
 class Scene {
   Scene(this.name);
 
   final String name;
   final List<Entity> entities = [];
+  final List<VectorVisual> vectors = [];
 
   void add(Entity e) => entities.add(e);
 
@@ -16,5 +18,18 @@ class Scene {
 
   void render(Canvas canvas) {
     entities.forEach((e) => e.render(canvas));
+    vectors.forEach((v) => v.render(canvas));
+  }
+
+  void toggleVectors(bool on) {
+    vectors.clear();
+    if (on) {
+      for (final entity in entities) {
+        final entityVectors = entity.vectors;
+        for (var i = 0; i < entityVectors.length; i++) {
+          vectors.add(VectorVisual(entity.position, entityVectors[i], i));
+        }
+      }
+    }
   }
 }

--- a/sandbox/lib/scene.dart
+++ b/sandbox/lib/scene.dart
@@ -7,7 +7,6 @@ class Scene {
 
   final String name;
   final List<Entity> entities = [];
-  final bool showVectors = true;
 
   void add(Entity e) => entities.add(e);
 
@@ -17,8 +16,5 @@ class Scene {
 
   void render(Canvas canvas) {
     entities.forEach((e) => e.render(canvas));
-    if (showVectors) {
-      entities.forEach((e) => e.renderVectors(canvas));
-    }
   }
 }

--- a/sandbox/lib/widgets/scene_widget.dart
+++ b/sandbox/lib/widgets/scene_widget.dart
@@ -87,15 +87,8 @@ class _ScenePainter extends CustomPainter {
     for (var i = -100.0; i <= 100.0; i += 20.0) {
       canvas.drawLine(Offset(i, -80), Offset(i, 80), gridPaint);
     }
-    _paintScene(canvas);
+    app.currentScene.render(canvas);
     canvas.restore();
-  }
-
-  void _paintScene(Canvas canvas) {
-    final scene = app.currentScene;
-    for (final entity in scene.entities) {
-      entity.render(canvas);
-    }
   }
 
   @override

--- a/sandbox/lib/widgets/top_menu.dart
+++ b/sandbox/lib/widgets/top_menu.dart
@@ -23,6 +23,10 @@ class TopMenu extends StatelessWidget {
             onPressed: canStop ? _handleStop : null,
             child: const Icon(Icons.stop_rounded),
           ),
+          TextButton(
+            onPressed: _handleVectors,
+            child: const Icon(Icons.transform),
+          ),
         ],
       ),
     );
@@ -31,4 +35,5 @@ class TopMenu extends StatelessWidget {
   void _handleStart() => app.startEngine();
   void _handlePause() => app.pauseEngine();
   void _handleStop() => app.stopEngine();
+  void _handleVectors() => app.toggleVectors();
 }

--- a/test/steering/kinematics/basic_kinematics_test.dart
+++ b/test/steering/kinematics/basic_kinematics_test.dart
@@ -7,6 +7,13 @@ import '../../utils/simple_steerable.dart';
 
 void main() {
   group('BasicKinematics', () {
+    test('clone', () {
+      final kinematics = BasicKinematics();
+      final copy = kinematics.clone();
+      expect(copy, isA<BasicKinematics>());
+      expect(copy == kinematics, false);
+    });
+
     test('update', () {
       final agent = SimpleSteerable(
         position: Vector2(5, 10),

--- a/test/steering/kinematics/heavy_kinematics_test.dart
+++ b/test/steering/kinematics/heavy_kinematics_test.dart
@@ -14,6 +14,17 @@ void main() {
       final kinematics = HeavyKinematics(maxSpeed: 5, maxAcceleration: 3);
       expect(kinematics.maxSpeed, 5);
       expect(kinematics.maxAcceleration, 3);
+      expect(kinematics.acceleration, closeToVector(0, 0));
+    });
+
+    test('clone', () {
+      final kinematics = HeavyKinematics(maxSpeed: 7, maxAcceleration: 11);
+      kinematics.setAcceleration(Vector2(2, -1));
+      final copy = kinematics.clone();
+      expect(copy, isA<HeavyKinematics>());
+      expect(copy.maxSpeed, 7);
+      expect(copy.maxAcceleration, 11);
+      expect(copy.acceleration, closeToVector(2, -1));
     });
 
     test('maxSpeed', () {
@@ -43,6 +54,7 @@ void main() {
       agent.update(1);
       expect(agent.velocity, closeToVector(0, 0));
       kinematics.setAcceleration(Vector2(10, 0));
+      expect(kinematics.acceleration, closeToVector(10, 0));
       // Second update changes velocity (because there's acceleration set)
       agent.update(1);
       expect(agent.position, closeToVector(0, 0));

--- a/test/steering/kinematics/light_kinematics_test.dart
+++ b/test/steering/kinematics/light_kinematics_test.dart
@@ -17,6 +17,13 @@ void main() {
       expect(kinematics.maxSpeed, 10);
     });
 
+    test('clone', () {
+      final kinematics = LightKinematics(23);
+      final copy = kinematics.clone();
+      expect(copy, isA<LightKinematics>());
+      expect(copy.maxSpeed, 23);
+    });
+
     test('speed errors', () {
       expect(
         () => LightKinematics(0),

--- a/test/steering/kinematics_test.dart
+++ b/test/steering/kinematics_test.dart
@@ -7,6 +7,13 @@ import '../utils/throws.dart';
 
 void main() {
   group('Kinematics', () {
+    test('clone', () {
+      final k1 = NonceKinematics();
+      final k2 = k1.clone();
+      expect(k2, isA<NonceKinematics>());
+      expect(k1 == k2, false);
+    });
+
     test('behavior factories', () {
       final agent = SimpleSteerable(kinematics: NonceKinematics());
 
@@ -28,6 +35,9 @@ void main() {
 }
 
 class NonceKinematics extends Kinematics {
+  @override
+  NonceKinematics clone() => NonceKinematics();
+
   @override
   void update(double dt) {}
 }


### PR DESCRIPTION
There is now a button in the top menu that toggles whether those vectors are shown or not.

In addition, sandbox `Entity`s and main library `Kinematic` objects can now be cloned.