### PR TITLE
feat: LightKinematics agent always faces the direction where it is moving

### DIFF
--- a/lib/src/steering/behaviors/seek.dart
+++ b/lib/src/steering/behaviors/seek.dart
@@ -47,7 +47,11 @@ class SeekLight extends Seek {
     if (maxSpeed * dt > distance) {
       maxSpeed = distance / dt;
     }
-    kinematics.setVelocity(offset..scale(maxSpeed));
+    if (maxSpeed == 0) {
+      kinematics.stop();
+    } else {
+      kinematics.setVelocity(offset..scale(maxSpeed));
+    }
   }
 }
 

--- a/lib/src/steering/kinematics.dart
+++ b/lib/src/steering/kinematics.dart
@@ -13,26 +13,23 @@ import 'steerable.dart';
 /// those steering controls to affect the motion of the owner.
 ///
 /// The main method of this class -- `update()` -- must be invoked by the user
-/// periodically, as time progresses, in order to confer motion to the [own]
+/// periodically, as time progresses, in order to confer motion to the [owner]
 /// steerable. For better results, this method should be invoked as frequently
 /// as possible.
 ///
 /// The method `handleAttach()` must be called by the user when the kinematics
 /// object is attached to a concrete [Steerable].
 abstract class Kinematics {
-  /// Returns a copy of this kinematics object, except for the [own] field.
-  Kinematics clone();
-
   /// Reference to the object being steered.
   ///
   /// This variable will be set within the `handleAttach()` method, and will
   /// always satisfy the constraint that `own.kinematics == this`.
-  late Steerable own;
+  late Steerable owner;
 
   /// This method must be invoked by the [parent] once, when this object is
   /// attached to the parent.
   @mustCallSuper
-  void handleAttach(Steerable parent) => own = parent;
+  void handleAttach(Steerable parent) => owner = parent;
 
   /// Invoked by the user to signal that time [dt] (in seconds) has passed
   /// within the system.
@@ -42,7 +39,7 @@ abstract class Kinematics {
   /// simulation.
   ///
   /// Within this method the implementation must advance the state of the object
-  /// and of the [own] steerable forward by [dt] seconds. The implementation
+  /// and of the [owner] steerable forward by [dt] seconds. The implementation
   /// may ignore any numeric effects that are `o(dt)`.
   void update(double dt);
 

--- a/lib/src/steering/kinematics/basic_kinematics.dart
+++ b/lib/src/steering/kinematics/basic_kinematics.dart
@@ -5,12 +5,9 @@ import '../kinematics.dart';
 /// values.
 class BasicKinematics extends Kinematics {
   @override
-  BasicKinematics clone() => BasicKinematics();
-
-  @override
   void update(double dt) {
-    own.position.x += own.velocity.x * dt;
-    own.position.y += own.velocity.y * dt;
-    own.angle += own.angularVelocity * dt;
+    owner.position.x += owner.velocity.x * dt;
+    owner.position.y += owner.velocity.y * dt;
+    owner.angle += owner.angularVelocity * dt;
   }
 }

--- a/lib/src/steering/kinematics/heavy_kinematics.dart
+++ b/lib/src/steering/kinematics/heavy_kinematics.dart
@@ -37,14 +37,6 @@ class HeavyKinematics extends Kinematics {
     _maxAcceleration = value;
   }
 
-  @override
-  HeavyKinematics clone() {
-    return HeavyKinematics(
-      maxSpeed: _maxSpeed,
-      maxAcceleration: _maxAcceleration,
-    )..setAcceleration(_acceleration);
-  }
-
   /// Acceleration that will be applied to the owner on the next tick.
   Vector2 get acceleration => _acceleration;
   final Vector2 _acceleration;
@@ -58,19 +50,19 @@ class HeavyKinematics extends Kinematics {
 
   @override
   void update(double dt) {
-    own.position.addScaled(own.velocity, dt);
-    own.velocity.addScaled(_acceleration, dt);
-    final v = own.velocity.length;
+    owner.position.addScaled(owner.velocity, dt);
+    owner.velocity.addScaled(_acceleration, dt);
+    final v = owner.velocity.length;
     if (v > maxSpeed) {
-      own.velocity.scale(maxSpeed / v);
+      owner.velocity.scale(maxSpeed / v);
     }
   }
 
   @override
-  Seek seek(Vector2 point) => SeekHeavy(owner: own, point: point);
+  Seek seek(Vector2 point) => SeekHeavy(owner: owner, point: point);
 
   @override
   Flee flee(List<Vector2> targets) {
-    return FleeHeavy(owner: own, targets: targets);
+    return FleeHeavy(owner: owner, targets: targets);
   }
 }

--- a/lib/src/steering/kinematics/light_kinematics.dart
+++ b/lib/src/steering/kinematics/light_kinematics.dart
@@ -1,12 +1,16 @@
 import 'package:vector_math/vector_math_64.dart';
 
+import '../../options/angles.dart';
 import '../behaviors/flee.dart';
 import '../behaviors/seek.dart';
 import 'basic_kinematics.dart';
 
-/// [LightKinematics] describes a character who can move freely in any
-/// direction with speeds up to `maxSpeed`, and change their velocity
-/// instantaneously with no regard to inertia.
+/// [LightKinematics] describes an agent who can move freely in any direction
+/// with speeds up to `maxSpeed`, and change their velocity instantaneously
+/// without any inertia.
+///
+/// This kinematics also forces the agent to always look in the direction of its
+/// velocity, turning instantly when the velocity changes.
 ///
 /// Use this for small lightweight creatures, like ants, or in situations where
 /// physical realism is not needed.
@@ -14,18 +18,21 @@ class LightKinematics extends BasicKinematics {
   LightKinematics(this._maxSpeed)
       : assert(_maxSpeed > 0, 'maxSpeed must be positive');
 
+  /// Maximum speed with which this agent can move.
+  ///
+  /// This speed cannot be negative or zero. Reducing the `maxSpeed` will also
+  /// reduce the current agent's velocity, if it's greater than the new speed
+  /// limit.
   double get maxSpeed => _maxSpeed;
   double _maxSpeed;
   set maxSpeed(double value) {
     assert(value > 0, 'maxSpeed must be positive');
     _maxSpeed = value;
+    setVelocitySafe(owner.velocity);
   }
 
-  @override
-  LightKinematics clone() => LightKinematics(_maxSpeed);
-
   void stop() {
-    own.velocity.setZero();
+    owner.velocity.setZero();
   }
 
   void setVelocity(Vector2 value) {
@@ -33,20 +40,22 @@ class LightKinematics extends BasicKinematics {
       value.length2 <= maxSpeed * maxSpeed * (1 + 1e-8),
       'Trying to set velocity=$value larger than maxSpeed=$maxSpeed',
     );
-    own.velocity.setFrom(value);
+    owner.velocity.setFrom(value);
+    owner.angle = vectorToAngle(owner.velocity);
   }
 
   void setVelocitySafe(Vector2 value) {
     final speed = value.length;
-    own.velocity.setFrom(value);
+    owner.velocity.setFrom(value);
+    owner.angle = vectorToAngle(owner.velocity);
     if (speed > maxSpeed) {
-      own.velocity.scale(maxSpeed / speed);
+      owner.velocity.scale(maxSpeed / speed);
     }
   }
 
   @override
-  Seek seek(Vector2 target) => SeekLight(owner: own, point: target);
+  Seek seek(Vector2 target) => SeekLight(owner: owner, point: target);
 
   @override
-  Flee flee(List<Vector2> targets) => FleeLight(owner: own, targets: targets);
+  Flee flee(List<Vector2> targets) => FleeLight(owner: owner, targets: targets);
 }

--- a/sandbox/lib/main.dart
+++ b/sandbox/lib/main.dart
@@ -1,4 +1,8 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
+import 'package:radiance/steering.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 import 'presets.dart';
 import 'scene.dart';
@@ -7,6 +11,9 @@ import 'widgets/scene_widget.dart';
 import 'widgets/top_menu.dart';
 
 void main() {
+  vectorToAngle = (Vector2 vector) => atan2(vector.y, vector.x);
+  angleToVector = (double angle) => Vector2(cos(angle), sin(angle));
+
   runApp(
     MaterialApp(
       title: 'Radiance sandbox',

--- a/test/steering/behaviors/seek_test.dart
+++ b/test/steering/behaviors/seek_test.dart
@@ -1,8 +1,6 @@
 import 'dart:math';
 
-import 'package:radiance/src/steering/behaviors/seek.dart';
-import 'package:radiance/src/steering/kinematics/heavy_kinematics.dart';
-import 'package:radiance/src/steering/kinematics/light_kinematics.dart';
+import 'package:radiance/steering.dart';
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
@@ -12,7 +10,7 @@ import '../../utils/test_random.dart';
 
 void main() {
   group('Seek', () {
-    group(':MaxSpeedKinematics', () {
+    group(':LightKinematics', () {
       test('properties', () {
         final agent = SimpleSteerable(kinematics: LightKinematics(10));
         final behavior = Seek(owner: agent, point: Vector2(20, 50));
@@ -35,7 +33,7 @@ void main() {
         final target = Vector2.random(rng) * 100;
         final seeker = SimpleSteerable(
           velocity: Vector2.random() * maxSpeed,
-          position: origin,
+          position: origin.clone(),
           kinematics: LightKinematics(maxSpeed),
         );
         seeker.behavior = Seek(owner: seeker, point: target);
@@ -50,10 +48,11 @@ void main() {
           closeToVector(target.x, target.y, epsilon: 1e-5),
         );
         expect(seeker.velocity, closeToVector(0, 0));
+        expect(seeker.angle, closeTo(vectorToAngle(target - origin), 1e-10));
       });
     });
 
-    group(':MaxAccelerationKinematics', () {
+    group(':HeavyKinematics', () {
       test('properties', () {
         final agent = SimpleSteerable(
           kinematics: HeavyKinematics(

--- a/test/steering/kinematics/basic_kinematics_test.dart
+++ b/test/steering/kinematics/basic_kinematics_test.dart
@@ -7,13 +7,6 @@ import '../../utils/simple_steerable.dart';
 
 void main() {
   group('BasicKinematics', () {
-    test('clone', () {
-      final kinematics = BasicKinematics();
-      final copy = kinematics.clone();
-      expect(copy, isA<BasicKinematics>());
-      expect(copy == kinematics, false);
-    });
-
     test('update', () {
       final agent = SimpleSteerable(
         position: Vector2(5, 10),

--- a/test/steering/kinematics/heavy_kinematics_test.dart
+++ b/test/steering/kinematics/heavy_kinematics_test.dart
@@ -17,16 +17,6 @@ void main() {
       expect(kinematics.acceleration, closeToVector(0, 0));
     });
 
-    test('clone', () {
-      final kinematics = HeavyKinematics(maxSpeed: 7, maxAcceleration: 11);
-      kinematics.setAcceleration(Vector2(2, -1));
-      final copy = kinematics.clone();
-      expect(copy, isA<HeavyKinematics>());
-      expect(copy.maxSpeed, 7);
-      expect(copy.maxAcceleration, 11);
-      expect(copy.acceleration, closeToVector(2, -1));
-    });
-
     test('maxSpeed', () {
       final kinematics = HeavyKinematics(maxSpeed: 5, maxAcceleration: 3);
       kinematics.maxSpeed = 1;

--- a/test/steering/kinematics/light_kinematics_test.dart
+++ b/test/steering/kinematics/light_kinematics_test.dart
@@ -49,9 +49,9 @@ void main() {
       expect(agent.angle, 0);
       kinematics.setVelocity(Vector2(5, 8));
       expect(agent.velocity, closeToVector(5, 8));
-      expect(agent.angle, -atan(8/5));
+      expect(agent.angle, -atan(8 / 5));
       kinematics.setVelocity(Vector2(6, 8));
-      expect(agent.angle, -atan(8/6));
+      expect(agent.angle, -atan(8 / 6));
       kinematics.setVelocity(Vector2(6 + 1e-10, 8 + 1e-10));
       expect(agent.velocity, closeToVector(6 + 1e-10, 8 + 1e-10));
       expect(
@@ -74,7 +74,7 @@ void main() {
       expect(agent.velocity, closeToVector(6, 8));
       kinematics.setVelocitySafe(Vector2(12, -16));
       expect(agent.velocity, closeToVector(6, -8));
-      expect(agent.angle, atan(8/6));
+      expect(agent.angle, atan(8 / 6));
     });
 
     test('changing maxSpeed reduces velocity', () {

--- a/test/steering/kinematics/light_kinematics_test.dart
+++ b/test/steering/kinematics/light_kinematics_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:radiance/src/steering/behaviors/flee.dart';
 import 'package:radiance/src/steering/behaviors/seek.dart';
 import 'package:radiance/steering.dart';
@@ -13,15 +15,6 @@ void main() {
     test('basic properties', () {
       final kinematics = LightKinematics(5);
       expect(kinematics.maxSpeed, 5);
-      kinematics.maxSpeed = 10;
-      expect(kinematics.maxSpeed, 10);
-    });
-
-    test('clone', () {
-      final kinematics = LightKinematics(23);
-      final copy = kinematics.clone();
-      expect(copy, isA<LightKinematics>());
-      expect(copy.maxSpeed, 23);
     });
 
     test('speed errors', () {
@@ -53,9 +46,12 @@ void main() {
         velocity: Vector2(3, 4),
         kinematics: kinematics,
       );
+      expect(agent.angle, 0);
       kinematics.setVelocity(Vector2(5, 8));
       expect(agent.velocity, closeToVector(5, 8));
+      expect(agent.angle, -atan(8/5));
       kinematics.setVelocity(Vector2(6, 8));
+      expect(agent.angle, -atan(8/6));
       kinematics.setVelocity(Vector2(6 + 1e-10, 8 + 1e-10));
       expect(agent.velocity, closeToVector(6 + 1e-10, 8 + 1e-10));
       expect(
@@ -78,6 +74,19 @@ void main() {
       expect(agent.velocity, closeToVector(6, 8));
       kinematics.setVelocitySafe(Vector2(12, -16));
       expect(agent.velocity, closeToVector(6, -8));
+      expect(agent.angle, atan(8/6));
+    });
+
+    test('changing maxSpeed reduces velocity', () {
+      final kinematics = LightKinematics(10);
+      final agent = SimpleSteerable(
+        velocity: Vector2(3, 4),
+        kinematics: kinematics,
+      );
+      expect(agent.velocity, closeToVector(3, 4));
+      kinematics.maxSpeed = 1;
+      expect(agent.velocity, closeToVector(0.6, 0.8));
+      expect(kinematics.maxSpeed, 1);
     });
 
     test('seek', () {

--- a/test/steering/kinematics_test.dart
+++ b/test/steering/kinematics_test.dart
@@ -7,13 +7,6 @@ import '../utils/throws.dart';
 
 void main() {
   group('Kinematics', () {
-    test('clone', () {
-      final k1 = NonceKinematics();
-      final k2 = k1.clone();
-      expect(k2, isA<NonceKinematics>());
-      expect(k1 == k2, false);
-    });
-
     test('behavior factories', () {
       final agent = SimpleSteerable(kinematics: NonceKinematics());
 
@@ -35,9 +28,6 @@ void main() {
 }
 
 class NonceKinematics extends Kinematics {
-  @override
-  NonceKinematics clone() => NonceKinematics();
-
   @override
   void update(double dt) {}
 }

--- a/test/steering/steerable_test.dart
+++ b/test/steering/steerable_test.dart
@@ -32,7 +32,7 @@ void main() {
     // containing Steerable object.
     test('kinematics.own', () {
       final Steerable steerable = SimpleSteerable();
-      expect(steerable.kinematics.own, steerable);
+      expect(steerable.kinematics.owner, steerable);
     });
   });
 }


### PR DESCRIPTION
- Agents with `LightKinematics` will now always face the direction of their velocity.
- Seek behavior for LightKinematics agents will now stop at the target without changing the orientation.
- Reducing `maxSpeed` of a `LightKinematics` agent will now also scale down its velocity.
- Field `Kinematics.own` renamed into `owner`.
- Fixed angle calculations in Sandbox.
- Cloning of Kinematics objects removed (since it cannot be adequately expanded to cloning of behaviors).